### PR TITLE
Set variant and version bits per RFC 4122

### DIFF
--- a/uuid.go
+++ b/uuid.go
@@ -21,6 +21,8 @@ func GenerateUUID() (string, error) {
 	if err != nil {
 		return "", err
 	}
+	buf[6] = buf[6]&0x0f | 0x40
+	buf[8] = buf[8]&0x3f | 0x80
 	return FormatUUID(buf)
 }
 


### PR DESCRIPTION
RFC 4122 specifies the UUID v4 algorithm in section 4.4:
```
   o  Set the two most significant bits (bits 6 and 7) of the
      clock_seq_hi_and_reserved to zero and one, respectively.

   o  Set the four most significant bits (bits 12 through 15) of the
      time_hi_and_version field to the 4-bit version number from
      Section 4.1.3.

   o  Set all the other bits to randomly (or pseudo-randomly) chosen
      values.
```