### PR TITLE
Update LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright © 2015-2022 HashiCorp, Inc.
+Copyright (c) 2015 HashiCorp, Inc.
 
 Mozilla Public License, version 2.0
 


### PR DESCRIPTION
A recent audit of public HashiCorp repos identified this LICENSE file as not adhering to our standard format. This commit brings the LICENSE file back into compliance with HashiCorp OSS best practices.