### PR TITLE
fix: trim surrounding space in ParseUUID

### DIFF
--- a/uuid.go
+++ b/uuid.go
@@ -8,6 +8,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
+	"strings"
 )
 
 // GenerateRandomBytes is used to generate random bytes of given size.
@@ -60,6 +61,7 @@ func FormatUUID(buf []byte) (string, error) {
 }
 
 func ParseUUID(uuid string) ([]byte, error) {
+	uuid = strings.TrimSpace(uuid)
 	if len(uuid) != 2*uuidLen+4 {
 		return nil, fmt.Errorf("uuid string is wrong length")
 	}

--- a/uuid_test.go
+++ b/uuid_test.go
@@ -98,3 +98,21 @@ func BenchmarkGenerateUUIDWithReader(b *testing.B) {
 		_, _ = GenerateUUIDWithReader(rand.Reader)
 	}
 }
+
+func TestParseUUIDTrimSpace(t *testing.T) {
+	id, err := GenerateUUID()
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := ParseUUID("  " + id + "\n")
+	if err != nil {
+		t.Fatal(err)
+	}
+	formatted, err := FormatUUID(b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if formatted != id {
+		t.Fatalf("got %s want %s", formatted, id)
+	}
+}


### PR DESCRIPTION
## What

`ParseUUID` trims leading/trailing whitespace before validating length and hyphens.

## Why

UUIDs from env vars and config often have padding. Valid IDs should not fail only because of surrounding space.

## Test

- `TestParseUUIDTrimSpace`